### PR TITLE
Entry and tests

### DIFF
--- a/src/main/scala/com/rhdzmota/fbmessenger/webhook/model/Entry.scala
+++ b/src/main/scala/com/rhdzmota/fbmessenger/webhook/model/Entry.scala
@@ -1,5 +1,5 @@
 package com.rhdzmota.fbmessenger.webhook.model
 
-class Entry {
+import com.rhdzmota.fbmessenger.webhook.model.message.Message
 
-}
+case class Entry(id: String, time: BigInt, messaging: List[Message])

--- a/src/test/scala/com/rhdzmota/fbmessenger/webhook/model/EntrySpec.scala
+++ b/src/test/scala/com/rhdzmota/fbmessenger/webhook/model/EntrySpec.scala
@@ -1,5 +1,32 @@
 package com.rhdzmota.fbmessenger.webhook.model
 
-class EntrySpec {
+import com.rhdzmota.fbmessenger.webhook.model.attachment.{Coordinates, Location, LocationPayload}
+import com.rhdzmota.fbmessenger.webhook.model.message.{Message, Recipient, Sender, WithLocation}
+import org.scalatest.{FlatSpec, Matchers}
+import io.circe.parser.decode
+import io.circe.generic.auto._
+import io.circe.syntax._
+
+class EntrySpec extends FlatSpec with Matchers {
+
+  "An Entry " should "jsonify correcty" in {
+    val coordinates = Coordinates(0.0, 0.0)
+    val locationPayload = LocationPayload(coordinates)
+    val location = Location("<TITLE>", "<URL>", "location", Some(locationPayload))
+    val withLocation = WithLocation("<MID>", 0, List(location))
+    val message = Message(Sender("<PSID>"), Recipient("<PAGE_ID>"), 0, withLocation)
+    val entry = Entry("<PAGE_ID>", 0, List(message))
+    val jsonString = "{\"id\": \"<PAGE_ID>\", \"time\": 0, \"messaging\": [{" +
+      "\"sender\": {\"id\": \"<PSID>\"}, \"recipient: {\"id\": \"<PAGE_ID>\"}, \"timestamp\": 0, \"message\": {" +
+      "\"mid\": \"<MID>\", \"seq\": 0, \"attachments\": [{" +
+      "\"title\": \"<TITLE>\", \"url\": \"<URL>\", \"type\": \"location\", \"payload\": {\"coordinates\": {\"lat\": 0.0, \"long\": 0.0}}" +
+      "}]" +
+      "}" +
+      "}]}"
+    decode[Message](jsonString).foreach(x => {
+      x shouldBe message
+      x.asJson shouldBe message.asJson
+    })
+  }
 
 }


### PR DESCRIPTION
#  Description
#### What does this PR do? 
This PR has the implementation of an Entry and the corresponding tests.

#### Relevant changes
See the `model` package and the `Entry` class.

# To the reviewer
#### Context 
A fb-messenger webhook event contains a list of entries. 

#### Where to start
See the test/functionality at: `EntrySpec`.

#### Tests instructions
Run: `sbt test`

# Self-Evaluation Keypoints
To the owner of this PR: answer 'yes' if the following key points are met. 
* Single responsibility principle: **yes**
* Code builds/run: **yes**
* Tests: **yes**
* Self-documented: **yes**  
* Consistent code-style: **yes**
* Subjective best-practices: **yes**

# Requests and further questions 
None. 